### PR TITLE
Uses layer file stream directly, no reading into string.

### DIFF
--- a/client/v2_2/docker_image_.py
+++ b/client/v2_2/docker_image_.py
@@ -781,6 +781,7 @@ class FromDisk(DockerImage):
     """Override."""
     if digest not in self._layer_to_filename:
       return self._legacy_base.blob(digest)
+    print('getting blob for ' + self._layer_to_filename[digest])
     # Might want to ensure this is closed.
     return open(self._layer_to_filename[digest], 'rb')
 

--- a/client/v2_2/docker_image_.py
+++ b/client/v2_2/docker_image_.py
@@ -781,8 +781,8 @@ class FromDisk(DockerImage):
     """Override."""
     if digest not in self._layer_to_filename:
       return self._legacy_base.blob(digest)
-    with open(self._layer_to_filename[digest], 'rb') as reader:
-      return reader.read()
+    # Might want to ensure this is closed.
+    return open(self._layer_to_filename[digest], 'rb')
 
   def blob_size(self, digest):
     """Override."""


### PR DESCRIPTION
This resolves the 2GB limit for image layers, which was because Python `requests` has 2GB limit on string size for request body.